### PR TITLE
Clarifying links in the menubar.

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -21,10 +21,11 @@
 				<div class="section">
 					<ul>
 						<li><a href="/about.html">about</a></li>
-						<li><a href="http://jabbr.net/#/rooms/code52">jabbr</a></li>
 						<li><a href="http://twitter.com/code_52">@code_52</a></li>
-						<li><a href="http://code52.uservoice.com">uservoice</a></li>
-						<li><a href="/contributing.html">contributing</a></li>
+						<li><a href="http://jabbr.net/#/rooms/code52">jabbr chatroom</a></li>
+						<li><a href="http://code52.uservoice.com">uservoice project voting</a></li>
+						<li><a href="/contributing.html">contributing guide</a></li>
+						<li><a href="https://github.com/Code52/code52.github.com/wiki">getting started</a></li>
 						<li><a href="/projects.html">previous projects</a></li>
 						<li><a href="/rss.xml"><img src="/img/25.png" /> announcements</a></li>
 						<li><a href="/projectsrss.xml"><img src="/img/25.png" /> progress logs</a></li>


### PR DESCRIPTION
A few of the links in the menu were just names of websites, not the
functions available within (chat room, project voting). Tried to clarify
the meaning of each of the links.
Added a link to the getting started wiki
